### PR TITLE
Add gitignore for .NET artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Ignore build output directories
+**/[Bb]in/
+**/[Oo]bj/
+# Ignore user-specific files
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+# Ignore tool-specific directories
+.vs/
+.idea/
+# Ignore NuGet packages
+*.nupkg


### PR DESCRIPTION
## Summary
- add root `.gitignore` to exclude build outputs and IDE files

## Testing
- `dotnet test ClinicFlow/ClinicFlow.sln` *(fails: `dotnet` not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f6ce10384832987cabf854dab871a