### PR TITLE
Add MediatR command/query handlers

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ClinicFlow.Infrastructure\ClinicFlow.Infrastructure.csproj" />
+    <ProjectReference Include="..\ClinicFlow.Application\ClinicFlow.Application.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -1,5 +1,26 @@
+using ClinicFlow.Application;
+using ClinicFlow.Application.Patients;
+using ClinicFlow.Infrastructure;
+using MediatR;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure();
+
 var app = builder.Build();
+
+app.MapPost("/patients", async (AddPatientCommand command, IMediator mediator) =>
+{
+    await mediator.Send(command);
+    return Results.Ok();
+});
+
+app.MapGet("/patients/{id:guid}", async (Guid id, IMediator mediator) =>
+{
+    var patient = await mediator.Send(new GetPatientQuery(id));
+    return patient is not null ? Results.Ok(patient) : Results.NotFound();
+});
 
 app.MapGet("/", () => "Hello World!");
 

--- a/ClinicFlow/ClinicFlow.Application/Patients/AddPatientCommand.cs
+++ b/ClinicFlow/ClinicFlow.Application/Patients/AddPatientCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Patients;
+
+public record AddPatientCommand(Guid Id, string Name) : IRequest;

--- a/ClinicFlow/ClinicFlow.Application/Patients/AddPatientCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Patients/AddPatientCommandHandler.cs
@@ -1,0 +1,21 @@
+using MediatR;
+using ClinicFlow.Domain;
+
+namespace ClinicFlow.Application.Patients;
+
+public class AddPatientCommandHandler : IRequestHandler<AddPatientCommand>
+{
+    private readonly IPatientRepository _repository;
+
+    public AddPatientCommandHandler(IPatientRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(AddPatientCommand request, CancellationToken cancellationToken)
+    {
+        var patient = new Patient(request.Id, request.Name);
+        await _repository.AddAsync(patient);
+        return Unit.Value;
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/Patients/GetPatientQuery.cs
+++ b/ClinicFlow/ClinicFlow.Application/Patients/GetPatientQuery.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using ClinicFlow.Domain;
+
+namespace ClinicFlow.Application.Patients;
+
+public record GetPatientQuery(Guid Id) : IRequest<Patient?>;

--- a/ClinicFlow/ClinicFlow.Application/Patients/GetPatientQueryHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Patients/GetPatientQueryHandler.cs
@@ -1,0 +1,19 @@
+using MediatR;
+using ClinicFlow.Domain;
+
+namespace ClinicFlow.Application.Patients;
+
+public class GetPatientQueryHandler : IRequestHandler<GetPatientQuery, Patient?>
+{
+    private readonly IPatientRepository _repository;
+
+    public GetPatientQueryHandler(IPatientRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Patient?> Handle(GetPatientQuery request, CancellationToken cancellationToken)
+    {
+        return await _repository.GetAsync(request.Id);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/ServiceCollectionExtensions.cs
+++ b/ClinicFlow/ClinicFlow.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClinicFlow.Application;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(ServiceCollectionExtensions).Assembly));
+        return services;
+    }
+}

--- a/ClinicFlow/ClinicFlow.Domain/IPatientRepository.cs
+++ b/ClinicFlow/ClinicFlow.Domain/IPatientRepository.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace ClinicFlow.Domain;
+
+public interface IPatientRepository
+{
+    Task AddAsync(Patient patient);
+    Task<Patient?> GetAsync(Guid id);
+}

--- a/ClinicFlow/ClinicFlow.Domain/Patient.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Patient.cs
@@ -1,0 +1,3 @@
+namespace ClinicFlow.Domain;
+
+public record Patient(Guid Id, string Name);

--- a/ClinicFlow/ClinicFlow.Infrastructure/Repositories/InMemoryPatientRepository.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Repositories/InMemoryPatientRepository.cs
@@ -1,0 +1,21 @@
+using ClinicFlow.Domain;
+using System.Collections.Concurrent;
+
+namespace ClinicFlow.Infrastructure.Repositories;
+
+public class InMemoryPatientRepository : IPatientRepository
+{
+    private readonly ConcurrentDictionary<Guid, Patient> _patients = new();
+
+    public Task AddAsync(Patient patient)
+    {
+        _patients[patient.Id] = patient;
+        return Task.CompletedTask;
+    }
+
+    public Task<Patient?> GetAsync(Guid id)
+    {
+        _patients.TryGetValue(id, out var patient);
+        return Task.FromResult(patient);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/ServiceCollectionExtensions.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using ClinicFlow.Domain;
+using ClinicFlow.Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ClinicFlow.Infrastructure;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+    {
+        services.AddSingleton<IPatientRepository, InMemoryPatientRepository>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- add Patient entity and repository interface
- implement AddPatient and GetPatient commands with handlers
- provide service registration for MediatR and infrastructure
- add in-memory repository implementation
- wire up MediatR endpoints in API

## Testing
- `dotnet build ClinicFlow/ClinicFlow.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f71a3411c832996e4976ca8095f02