### PR TITLE
Add EF Core domain entities and DbContext

### DIFF
--- a/ClinicFlow/ClinicFlow.Domain/Entities/Appointment.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Entities/Appointment.cs
@@ -1,0 +1,13 @@
+namespace ClinicFlow.Domain.Entities;
+
+public class Appointment
+{
+    public int Id { get; set; }
+    public DateTime ScheduledAt { get; set; }
+
+    public int PatientId { get; set; }
+    public Patient? Patient { get; set; }
+
+    public int DoctorId { get; set; }
+    public Doctor? Doctor { get; set; }
+}

--- a/ClinicFlow/ClinicFlow.Domain/Entities/Doctor.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Entities/Doctor.cs
@@ -1,0 +1,11 @@
+namespace ClinicFlow.Domain.Entities;
+
+public class Doctor
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string Specialty { get; set; } = string.Empty;
+
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/ClinicFlow/ClinicFlow.Domain/Entities/Patient.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Entities/Patient.cs
@@ -1,0 +1,11 @@
+namespace ClinicFlow.Domain.Entities;
+
+public class Patient
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public DateTime DateOfBirth { get; set; }
+
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj
+++ b/ClinicFlow/ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj
@@ -2,6 +2,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ClinicFlow.Application\ClinicFlow.Application.csproj" />
+    <ProjectReference Include="..\ClinicFlow.Domain\ClinicFlow.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using ClinicFlow.Domain.Entities;
+
+namespace ClinicFlow.Infrastructure.Data;
+
+public class ClinicFlowDbContext : DbContext
+{
+    public ClinicFlowDbContext(DbContextOptions<ClinicFlowDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Patient> Patients => Set<Patient>();
+    public DbSet<Doctor> Doctors => Set<Doctor>();
+    public DbSet<Appointment> Appointments => Set<Appointment>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Appointment>()
+            .HasOne(a => a.Patient)
+            .WithMany(p => p.Appointments)
+            .HasForeignKey(a => a.PatientId);
+
+        modelBuilder.Entity<Appointment>()
+            .HasOne(a => a.Doctor)
+            .WithMany(d => d.Appointments)
+            .HasForeignKey(a => a.DoctorId);
+    }
+}


### PR DESCRIPTION
## Summary
- define `Patient`, `Doctor`, and `Appointment` entities in the Domain project
- add `ClinicFlowDbContext` in Infrastructure project
- reference Domain project and EF Core packages from Infrastructure

## Testing
- `dotnet build ClinicFlow/ClinicFlow.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e78f6d3c8329a0648af8836d1f94