### PR TITLE
Add JWT auth and sample protected endpoints

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\ClinicFlow.Infrastructure\ClinicFlow.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -1,6 +1,73 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+
 var builder = WebApplication.CreateBuilder(args);
+
+var jwtSection = builder.Configuration.GetSection("Jwt");
+var jwtKey = jwtSection["Key"] ?? throw new InvalidOperationException("JWT Key not configured");
+var jwtIssuer = jwtSection["Issuer"];
+var jwtAudience = jwtSection["Audience"];
+
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            ValidateIssuer = true,
+            ValidIssuer = jwtIssuer,
+            ValidateAudience = true,
+            ValidAudience = jwtAudience,
+            ClockSkew = TimeSpan.Zero
+        };
+    });
+
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapGet("/", () => "Hello World!");
 
+app.MapGet("/public", () => "Public endpoint");
+
+app.MapGet("/protected", [Authorize]() => "You are authenticated!");
+
+app.MapGet("/admin", [Authorize(Roles = "Admin")] (ClaimsPrincipal user) =>
+    $"Hello {user.Identity?.Name}, you are an admin.");
+
+app.MapPost("/token", (UserCredential credential) =>
+{
+    if (credential.Username == "admin" && credential.Password == "password")
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, credential.Username),
+            new Claim(ClaimTypes.Role, "Admin")
+        };
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: jwtIssuer,
+            audience: jwtAudience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+        var tokenValue = new JwtSecurityTokenHandler().WriteToken(token);
+        return Results.Ok(new { token = tokenValue });
+    }
+
+    return Results.Unauthorized();
+});
+
 app.Run();
+
+record UserCredential(string Username, string Password);

--- a/ClinicFlow/ClinicFlow.API/appsettings.Development.json
+++ b/ClinicFlow/ClinicFlow.API/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "ClinicFlowAPI",
+    "Audience": "ClinicFlowUsers"
   }
 }

--- a/ClinicFlow/ClinicFlow.API/appsettings.json
+++ b/ClinicFlow/ClinicFlow.API/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "ClinicFlowAPI",
+    "Audience": "ClinicFlowUsers"
+  }
 }


### PR DESCRIPTION
## Summary
- add JwtBearer package
- configure JWT authentication in Program.cs
- expose token endpoint with role-based admin example
- add Jwt settings to appsettings files

## Testing
- `dotnet build ClinicFlow/ClinicFlow.sln` *(fails: command not found)*
- `dotnet test ClinicFlow/ClinicFlow.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e79099b483298c6f80c04fcc2046