### PR TITLE
Add greeting handler and tests

### DIFF
--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -4,6 +4,8 @@ using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
+using MediatR;
+using ClinicFlow.Application.Greetings;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -29,6 +31,7 @@ builder.Services
     });
 
 builder.Services.AddAuthorization();
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<GetGreetingQuery>());
 
 var app = builder.Build();
 
@@ -38,6 +41,12 @@ app.UseAuthorization();
 app.MapGet("/", () => "Hello World!");
 
 app.MapGet("/public", () => "Public endpoint");
+
+app.MapGet("/greeting", async (IMediator mediator) =>
+{
+    var message = await mediator.Send(new GetGreetingQuery());
+    return Results.Ok(message);
+});
 
 app.MapGet("/protected", [Authorize]() => "You are authenticated!");
 
@@ -71,3 +80,5 @@ app.MapPost("/token", (UserCredential credential) =>
 app.Run();
 
 record UserCredential(string Username, string Password);
+
+public partial class Program { }

--- a/ClinicFlow/ClinicFlow.Application/Greetings/GetGreetingQuery.cs
+++ b/ClinicFlow/ClinicFlow.Application/Greetings/GetGreetingQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Greetings;
+
+public record GetGreetingQuery() : IRequest<string>;

--- a/ClinicFlow/ClinicFlow.Application/Greetings/GetGreetingQueryHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Greetings/GetGreetingQueryHandler.cs
@@ -1,0 +1,11 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Greetings;
+
+public class GetGreetingQueryHandler : IRequestHandler<GetGreetingQuery, string>
+{
+    public Task<string> Handle(GetGreetingQuery request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult("Hello from MediatR!");
+    }
+}

--- a/ClinicFlow/ClinicFlow.Tests/Api/GreetingEndpointTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Api/GreetingEndpointTests.cs
@@ -1,0 +1,25 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace ClinicFlow.Tests.Api;
+
+public class GreetingEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public GreetingEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GreetingEndpoint_ReturnsExpectedMessage()
+    {
+        var response = await _client.GetAsync("/greeting");
+        response.EnsureSuccessStatusCode();
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Hello from MediatR!", content);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
+++ b/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClinicFlow.API\ClinicFlow.API.csproj" />
+    <ProjectReference Include="..\ClinicFlow.Application\ClinicFlow.Application.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/ClinicFlow/ClinicFlow.Tests/Handlers/GreetingHandlerTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Handlers/GreetingHandlerTests.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ClinicFlow.Application.Greetings;
+using Xunit;
+
+namespace ClinicFlow.Tests.Handlers;
+
+public class GreetingHandlerTests
+{
+    [Fact]
+    public async Task GetGreeting_ReturnsExpectedMessage()
+    {
+        var handler = new GetGreetingQueryHandler();
+        var result = await handler.Handle(new GetGreetingQuery(), CancellationToken.None);
+        Assert.Equal("Hello from MediatR!", result);
+    }
+}

--- a/ClinicFlow/ClinicFlow.sln
+++ b/ClinicFlow/ClinicFlow.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClinicFlow.Application", "C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClinicFlow.Infrastructure", "ClinicFlow.Infrastructure\ClinicFlow.Infrastructure.csproj", "{119AF31C-2F86-403E-9D7B-0B156B9EF769}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClinicFlow.Tests", "ClinicFlow.Tests\ClinicFlow.Tests.csproj", "{A1B2C3D4-E5F6-47A8-9BA1-1234567890AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,8 +35,12 @@ Global
 		{572451C2-6C25-4593-A8BB-986E0A94C7E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{572451C2-6C25-4593-A8BB-986E0A94C7E0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{119AF31C-2F86-403E-9D7B-0B156B9EF769}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{119AF31C-2F86-403E-9D7B-0B156B9EF769}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{119AF31C-2F86-403E-9D7B-0B156B9EF769}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{119AF31C-2F86-403E-9D7B-0B156B9EF769}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {119AF31C-2F86-403E-9D7B-0B156B9EF769}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {119AF31C-2F86-403E-9D7B-0B156B9EF769}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {119AF31C-2F86-403E-9D7B-0B156B9EF769}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A1B2C3D4-E5F6-47A8-9BA1-1234567890AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A1B2C3D4-E5F6-47A8-9BA1-1234567890AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A1B2C3D4-E5F6-47A8-9BA1-1234567890AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A1B2C3D4-E5F6-47A8-9BA1-1234567890AB}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add CQRS greeting query and handler
- expose `/greeting` API endpoint using MediatR
- create `ClinicFlow.Tests` xUnit project
- test the handler and the API endpoint

## Testing
- `dotnet test ClinicFlow/ClinicFlow.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881f4a5e46c8329a1ae03bfecd80f65