### PR TITLE
Set all projects to .NET 8

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
+++ b/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Domain/ClinicFlow.Domain.csproj
+++ b/ClinicFlow/ClinicFlow.Domain/ClinicFlow.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj
+++ b/ClinicFlow/ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
+++ b/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- unify TargetFramework across all projects to `net8.0`

## Testing
- `dotnet build ClinicFlow/ClinicFlow.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881faf630d8832989535a8bf94cccf0