### PR TITLE
Improve README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,51 @@ dotnet run --project ClinicFlow.API
 
 The application listens on the URLs defined in `appsettings.json` and `launchSettings.json`.
 
+## Usage
+
+1. **Request a token**
+   
+   Send a `POST` request to `/token` with JSON credentials:
+
+   ```bash
+   curl -X POST http://localhost:5000/token \
+     -H "Content-Type: application/json" \
+     -d '{ "username": "admin", "password": "password" }'
+   ```
+
+   The response contains a JWT token in the form:
+
+   ```json
+   { "token": "<your_token_here>" }
+   ```
+
+2. **Call protected routes**
+
+   Include the returned token in the `Authorization` header:
+
+   ```bash
+   curl http://localhost:5000/protected \
+     -H "Authorization: Bearer <your_token_here>"
+   ```
+
+3. **Example endpoints**
+   
+   - `/greeting` – returns a greeting from a Mediator handler
+   - `/public` – accessible without authentication
+   - `/protected` – requires a valid token
+   - `/admin` – accessible only to users with the `Admin` role
+
+JWT settings (issuer, audience, key) can be customized in `ClinicFlow.API/appsettings.json`.
+
+## Running Tests
+
+Execute unit tests using the .NET CLI:
+
+```bash
+cd ClinicFlow
+dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj
+```
+
 ## Notes
 
 This repository currently contains minimal starter code. Future work includes adding CQRS handlers, JWT authentication middleware, and infrastructure implementations.


### PR DESCRIPTION
## Summary
- document token endpoint usage
- show how to call protected APIs with the JWT token
- list example endpoints and reference JWT settings
- add instructions for running tests

## Testing
- `dotnet test ClinicFlow/ClinicFlow.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fc5898b083298d11041dd6d74fe4