### PR TITLE
Add user domain entity with DbContext updates

### DIFF
--- a/ClinicFlow/ClinicFlow.Domain/Entities/Appointment.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Entities/Appointment.cs
@@ -5,6 +5,9 @@ public class Appointment
     public int Id { get; set; }
     public DateTime ScheduledAt { get; set; }
 
+    public int UserId { get; set; }
+    public User? User { get; set; }
+
     public int PatientId { get; set; }
     public Patient? Patient { get; set; }
 

--- a/ClinicFlow/ClinicFlow.Domain/Entities/User.cs
+++ b/ClinicFlow/ClinicFlow.Domain/Entities/User.cs
@@ -1,0 +1,10 @@
+namespace ClinicFlow.Domain.Entities;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
@@ -13,6 +13,7 @@ public class ClinicFlowDbContext : DbContext
     public DbSet<Patient> Patients => Set<Patient>();
     public DbSet<Doctor> Doctors => Set<Doctor>();
     public DbSet<Appointment> Appointments => Set<Appointment>();
+    public DbSet<User> Users => Set<User>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -27,5 +28,10 @@ public class ClinicFlowDbContext : DbContext
             .HasOne(a => a.Doctor)
             .WithMany(d => d.Appointments)
             .HasForeignKey(a => a.DoctorId);
+
+        modelBuilder.Entity<Appointment>()
+            .HasOne(a => a.User)
+            .WithMany(u => u.Appointments)
+            .HasForeignKey(a => a.UserId);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `User` entity
- relate `Appointment` to `User`
- register `DbSet<User>` and configure relationship in `ClinicFlowDbContext`

## Testing
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883646c8c888329b36bdc807a1350d5