### PR TITLE
Add FluentValidation validators

### DIFF
--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -5,7 +5,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using MediatR;
+using FluentValidation;
 using ClinicFlow.Application.Greetings;
+using ClinicFlow.Application.Users;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -32,6 +34,7 @@ builder.Services
 
 builder.Services.AddAuthorization();
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<GetGreetingQuery>());
+builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserCommand>();
 
 var app = builder.Build();
 

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommand.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Appointments;
+
+public record CreateAppointmentCommand(int PatientId, int DoctorId, DateTime ScheduledAt) : IRequest<int>;

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandValidator.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace ClinicFlow.Application.Appointments;
+
+public class CreateAppointmentCommandValidator : AbstractValidator<CreateAppointmentCommand>
+{
+    public CreateAppointmentCommandValidator()
+    {
+        RuleFor(x => x.PatientId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.DoctorId)
+            .GreaterThan(0);
+
+        RuleFor(x => x.ScheduledAt)
+            .Must(d => d > DateTime.Now)
+            .WithMessage("Scheduled time must be in the future");
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
+++ b/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="FluentValidation" Version="11.7.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Application/Users/LoginQuery.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/LoginQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Users;
+
+public record LoginQuery(string Username, string Password) : IRequest<string>;

--- a/ClinicFlow/ClinicFlow.Application/Users/LoginQueryValidator.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/LoginQueryValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace ClinicFlow.Application.Users;
+
+public class LoginQueryValidator : AbstractValidator<LoginQuery>
+{
+    public LoginQueryValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty();
+
+        RuleFor(x => x.Password)
+            .NotEmpty();
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommand.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ClinicFlow.Application.Users;
+
+public record RegisterUserCommand(string Username, string Password) : IRequest;

--- a/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandValidator.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace ClinicFlow.Application.Users;
+
+public class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.Username)
+            .NotEmpty();
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(6);
+    }
+}


### PR DESCRIPTION
## Summary
- add FluentValidation package to the Application project
- implement validators for RegisterUserCommand, LoginQuery and CreateAppointmentCommand
- register validators in API startup

## Testing
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883646e8a0483298e4635099e957eaf