### PR TITLE
Implement registration/auth features with Serilog

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.API/appsettings.Development.json
+++ b/ClinicFlow/ClinicFlow.API/appsettings.Development.json
@@ -5,6 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": "Information",
+    "WriteTo": [ { "Name": "Console" } ]
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ClinicFlowDb;Trusted_Connection=True;"
+  },
   "Jwt": {
     "Key": "SuperSecretKey12345",
     "Issuer": "ClinicFlowAPI",

--- a/ClinicFlow/ClinicFlow.API/appsettings.json
+++ b/ClinicFlow/ClinicFlow.API/appsettings.json
@@ -5,6 +5,14 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": "Information",
+    "WriteTo": [ { "Name": "Console" } ]
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ClinicFlowDb;Trusted_Connection=True;"
+  },
   "AllowedHosts": "*",
   "Jwt": {
     "Key": "SuperSecretKey12345",

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandHandler.cs
@@ -1,0 +1,28 @@
+using ClinicFlow.Application.Common;
+using ClinicFlow.Domain.Entities;
+using MediatR;
+
+namespace ClinicFlow.Application.Appointments;
+
+public class CreateAppointmentCommandHandler : IRequestHandler<CreateAppointmentCommand, int>
+{
+    private readonly IAppointmentRepository _repository;
+
+    public CreateAppointmentCommandHandler(IAppointmentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<int> Handle(CreateAppointmentCommand request, CancellationToken cancellationToken)
+    {
+        var appointment = new Appointment
+        {
+            PatientId = request.PatientId,
+            DoctorId = request.DoctorId,
+            ScheduledAt = request.ScheduledAt,
+            UserId = 0
+        };
+
+        return await _repository.AddAsync(appointment, cancellationToken);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/Common/IAppointmentRepository.cs
+++ b/ClinicFlow/ClinicFlow.Application/Common/IAppointmentRepository.cs
@@ -1,0 +1,8 @@
+namespace ClinicFlow.Application.Common;
+
+using ClinicFlow.Domain.Entities;
+
+public interface IAppointmentRepository
+{
+    Task<int> AddAsync(Appointment appointment, CancellationToken cancellationToken = default);
+}

--- a/ClinicFlow/ClinicFlow.Application/Common/ITokenService.cs
+++ b/ClinicFlow/ClinicFlow.Application/Common/ITokenService.cs
@@ -1,0 +1,8 @@
+namespace ClinicFlow.Application.Common;
+
+using ClinicFlow.Domain.Entities;
+
+public interface ITokenService
+{
+    string GenerateToken(User user);
+}

--- a/ClinicFlow/ClinicFlow.Application/Common/IUserRepository.cs
+++ b/ClinicFlow/ClinicFlow.Application/Common/IUserRepository.cs
@@ -1,0 +1,9 @@
+namespace ClinicFlow.Application.Common;
+
+using ClinicFlow.Domain.Entities;
+
+public interface IUserRepository
+{
+    Task<User?> GetByUsernameAsync(string username, CancellationToken cancellationToken = default);
+    Task AddAsync(User user, CancellationToken cancellationToken = default);
+}

--- a/ClinicFlow/ClinicFlow.Application/Users/LoginQueryHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/LoginQueryHandler.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using System.Text;
+using ClinicFlow.Application.Common;
+using MediatR;
+
+namespace ClinicFlow.Application.Users;
+
+public class LoginQueryHandler : IRequestHandler<LoginQuery, string>
+{
+    private readonly IUserRepository _repository;
+    private readonly ITokenService _tokenService;
+
+    public LoginQueryHandler(IUserRepository repository, ITokenService tokenService)
+    {
+        _repository = repository;
+        _tokenService = tokenService;
+    }
+
+    public async Task<string> Handle(LoginQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _repository.GetByUsernameAsync(request.Username, cancellationToken);
+        if (user is null)
+        {
+            return string.Empty;
+        }
+
+        var hash = HashPassword(request.Password);
+        if (user.PasswordHash != hash)
+        {
+            return string.Empty;
+        }
+
+        return _tokenService.GenerateToken(user);
+    }
+
+    private static string HashPassword(string password)
+    {
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(password);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
@@ -1,0 +1,32 @@
+using System.Security.Cryptography;
+using System.Text;
+using ClinicFlow.Application.Common;
+using ClinicFlow.Domain.Entities;
+using MediatR;
+
+namespace ClinicFlow.Application.Users;
+
+public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
+{
+    private readonly IUserRepository _repository;
+
+    public RegisterUserCommandHandler(IUserRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    {
+        var hash = HashPassword(request.Password);
+        var user = new User { Username = request.Username, PasswordHash = hash };
+        await _repository.AddAsync(user, cancellationToken);
+    }
+
+    private static string HashPassword(string password)
+    {
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(password);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Repositories/AppointmentRepository.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Repositories/AppointmentRepository.cs
@@ -1,0 +1,22 @@
+using ClinicFlow.Application.Common;
+using ClinicFlow.Domain.Entities;
+using ClinicFlow.Infrastructure.Data;
+
+namespace ClinicFlow.Infrastructure.Repositories;
+
+public class AppointmentRepository : IAppointmentRepository
+{
+    private readonly ClinicFlowDbContext _context;
+
+    public AppointmentRepository(ClinicFlowDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<int> AddAsync(Appointment appointment, CancellationToken cancellationToken = default)
+    {
+        _context.Appointments.Add(appointment);
+        await _context.SaveChangesAsync(cancellationToken);
+        return appointment.Id;
+    }
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Repositories/UserRepository.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Repositories/UserRepository.cs
@@ -1,0 +1,27 @@
+using ClinicFlow.Application.Common;
+using ClinicFlow.Domain.Entities;
+using ClinicFlow.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace ClinicFlow.Infrastructure.Repositories;
+
+public class UserRepository : IUserRepository
+{
+    private readonly ClinicFlowDbContext _context;
+
+    public UserRepository(ClinicFlowDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(User user, CancellationToken cancellationToken = default)
+    {
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<User?> GetByUsernameAsync(string username, CancellationToken cancellationToken = default)
+    {
+        return _context.Users.FirstOrDefaultAsync(u => u.Username == username, cancellationToken);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Services/JwtSettings.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Services/JwtSettings.cs
@@ -1,0 +1,9 @@
+namespace ClinicFlow.Infrastructure.Services;
+
+public class JwtSettings
+{
+    public string Key { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public int ExpirationMinutes { get; set; } = 60;
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Services/TokenService.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Services/TokenService.cs
@@ -1,0 +1,38 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using ClinicFlow.Application.Common;
+using ClinicFlow.Domain.Entities;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ClinicFlow.Infrastructure.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly JwtSettings _settings;
+
+    public TokenService(IOptions<JwtSettings> options)
+    {
+        _settings = options.Value;
+    }
+
+    public string GenerateToken(User user)
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, user.Username)
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Key));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: _settings.Issuer,
+            audience: _settings.Audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(_settings.ExpirationMinutes),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/ClinicFlow/ClinicFlow.Tests/Api/AuthEndpointTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Api/AuthEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Json;
+using ClinicFlow.Infrastructure.Data;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ClinicFlow.Tests.Api;
+
+public class AuthEndpointTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public AuthEndpointTests(TestApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task RegisterAndLogin_Workflow()
+    {
+        var registerResponse = await _client.PostAsJsonAsync("/auth/register", new { username = "apiuser", password = "secret" });
+        registerResponse.EnsureSuccessStatusCode();
+
+        var loginResponse = await _client.PostAsJsonAsync("/auth/login", new { username = "apiuser", password = "secret" });
+        loginResponse.EnsureSuccessStatusCode();
+        var json = await loginResponse.Content.ReadFromJsonAsync<TokenResponse>();
+        Assert.False(string.IsNullOrEmpty(json?.token));
+    }
+
+    private record TokenResponse(string token);
+}
+
+public class TestApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ClinicFlowDbContext>));
+            if (descriptor != null)
+            {
+                services.Remove(descriptor);
+            }
+
+            services.AddDbContext<ClinicFlowDbContext>(options => options.UseInMemoryDatabase("api_test"));
+        });
+    }
+}

--- a/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
+++ b/ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj
@@ -5,6 +5,7 @@
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ClinicFlow/ClinicFlow.Tests/Handlers/LoginQueryHandlerTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Handlers/LoginQueryHandlerTests.cs
@@ -1,0 +1,33 @@
+using ClinicFlow.Application.Users;
+using ClinicFlow.Infrastructure.Data;
+using ClinicFlow.Infrastructure.Repositories;
+using ClinicFlow.Infrastructure.Services;
+using ClinicFlow.Application.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace ClinicFlow.Tests.Handlers;
+
+public class LoginQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsToken_WhenCredentialsValid()
+    {
+        var options = new DbContextOptionsBuilder<ClinicFlowDbContext>()
+            .UseInMemoryDatabase("login_test")
+            .Options;
+        using var context = new ClinicFlowDbContext(options);
+        IUserRepository repo = new UserRepository(context);
+        var registerHandler = new RegisterUserCommandHandler(repo);
+        await registerHandler.Handle(new RegisterUserCommand("user", "pass"), CancellationToken.None);
+
+        var settings = Options.Create(new JwtSettings { Key = "TestKey1234567890", Issuer = "Test", Audience = "Test" });
+        ITokenService tokenService = new TokenService(settings);
+        var handler = new LoginQueryHandler(repo, tokenService);
+
+        var token = await handler.Handle(new LoginQuery("user", "pass"), CancellationToken.None);
+
+        Assert.False(string.IsNullOrEmpty(token));
+    }
+}

--- a/ClinicFlow/ClinicFlow.Tests/Handlers/RegisterUserCommandHandlerTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Handlers/RegisterUserCommandHandlerTests.cs
@@ -1,0 +1,28 @@
+using ClinicFlow.Application.Users;
+using ClinicFlow.Infrastructure.Data;
+using ClinicFlow.Infrastructure.Repositories;
+using ClinicFlow.Application.Common;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace ClinicFlow.Tests.Handlers;
+
+public class RegisterUserCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_AddsUserToRepository()
+    {
+        var options = new DbContextOptionsBuilder<ClinicFlowDbContext>()
+            .UseInMemoryDatabase("register_test")
+            .Options;
+        using var context = new ClinicFlowDbContext(options);
+        IUserRepository repo = new UserRepository(context);
+        var handler = new RegisterUserCommandHandler(repo);
+
+        var command = new RegisterUserCommand("testuser", "secret");
+        await handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(1, context.Users.Count());
+        Assert.NotEqual("secret", context.Users.First().PasswordHash);
+    }
+}


### PR DESCRIPTION
## Summary
- add MediatR command/query handlers for registering users, logging in, and creating appointments
- provide repository interfaces and implementations for EF Core
- implement a token service generating JWTs
- configure API for Serilog, EF Core and new `/auth` endpoints
- add unit tests for handlers and auth endpoints

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883669d19ac8329a8063619b08db90f