### PR TITLE
Add initial EF Core migration

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -7,6 +7,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Data/ClinicFlowDbContext.cs
@@ -33,5 +33,13 @@ public class ClinicFlowDbContext : DbContext
             .HasOne(a => a.User)
             .WithMany(u => u.Appointments)
             .HasForeignKey(a => a.UserId);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(u => u.Username)
+            .IsUnique();
+
+        modelBuilder.Entity<Appointment>()
+            .HasIndex(a => a.ScheduledAt)
+            .IsClustered(false);
     }
 }

--- a/ClinicFlow/ClinicFlow.Infrastructure/Data/Migrations/20240101000000_InitialCreate.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Data/Migrations/20240101000000_InitialCreate.cs
@@ -1,0 +1,137 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ClinicFlow.Infrastructure.Data.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Doctors",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FirstName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    LastName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Specialty = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Doctors", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Patients",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FirstName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    LastName = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    DateOfBirth = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Patients", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Username = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    PasswordHash = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Appointments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ScheduledAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    PatientId = table.Column<int>(type: "int", nullable: false),
+                    DoctorId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Appointments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Appointments_Doctors_DoctorId",
+                        column: x => x.DoctorId,
+                        principalTable: "Doctors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Appointments_Patients_PatientId",
+                        column: x => x.PatientId,
+                        principalTable: "Patients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_Appointments_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Appointments_DoctorId",
+                table: "Appointments",
+                column: "DoctorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Appointments_PatientId",
+                table: "Appointments",
+                column: "PatientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Appointments_UserId",
+                table: "Appointments",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Username",
+                table: "Users",
+                column: "Username",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Appointments_ScheduledAt",
+                table: "Appointments",
+                column: "ScheduledAt")
+                .Annotation("SqlServer:Clustered", false);
+
+            migrationBuilder.Sql(@"CREATE PROCEDURE GetAppointmentsForDoctor @DoctorId INT AS BEGIN SELECT * FROM Appointments WHERE DoctorId = @DoctorId END");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP PROCEDURE IF EXISTS GetAppointmentsForDoctor");
+
+            migrationBuilder.DropTable(
+                name: "Appointments");
+
+            migrationBuilder.DropTable(
+                name: "Doctors");
+
+            migrationBuilder.DropTable(
+                name: "Patients");
+
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+}

--- a/ClinicFlow/ClinicFlow.Infrastructure/Data/Migrations/ClinicFlowDbContextModelSnapshot.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Data/Migrations/ClinicFlowDbContextModelSnapshot.cs
@@ -1,0 +1,155 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using ClinicFlow.Infrastructure.Data;
+
+#nullable disable
+
+namespace ClinicFlow.Infrastructure.Data.Migrations
+{
+    [DbContext(typeof(ClinicFlowDbContext))]
+    partial class ClinicFlowDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.0")
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("ClinicFlow.Domain.Entities.Appointment", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<int>("DoctorId")
+                    .HasColumnType("int");
+
+                b.Property<int>("PatientId")
+                    .HasColumnType("int");
+
+                b.Property<DateTime>("ScheduledAt")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("UserId")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.HasIndex("DoctorId");
+
+                b.HasIndex("PatientId");
+
+                b.HasIndex("UserId");
+
+                b.HasIndex("ScheduledAt")
+                    .IsClustered(false);
+
+                b.ToTable("Appointments");
+            });
+
+            modelBuilder.Entity("ClinicFlow.Domain.Entities.Doctor", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<string>("FirstName")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("LastName")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Specialty")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("Doctors");
+            });
+
+            modelBuilder.Entity("ClinicFlow.Domain.Entities.Patient", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<DateTime>("DateOfBirth")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("FirstName")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("LastName")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("Patients");
+            });
+
+            modelBuilder.Entity("ClinicFlow.Domain.Entities.User", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<string>("PasswordHash")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<string>("Username")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(450)");
+
+                b.HasKey("Id");
+
+                b.HasIndex("Username")
+                    .IsUnique();
+
+                b.ToTable("Users");
+            });
+
+            modelBuilder.Entity("ClinicFlow.Domain.Entities.Appointment", b =>
+            {
+                b.HasOne("ClinicFlow.Domain.Entities.Doctor", "Doctor")
+                    .WithMany("Appointments")
+                    .HasForeignKey("DoctorId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("ClinicFlow.Domain.Entities.Patient", "Patient")
+                    .WithMany("Appointments")
+                    .HasForeignKey("PatientId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("ClinicFlow.Domain.Entities.User", "User")
+                    .WithMany("Appointments")
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Doctor");
+
+                b.Navigation("Patient");
+
+                b.Navigation("User");
+            });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ dotnet run --project ClinicFlow.API
 
 The application listens on the URLs defined in `appsettings.json` and `launchSettings.json`.
 
+## Database
+
+Entity Framework Core migrations are included in the Infrastructure project. To apply them to the configured database run:
+
+```bash
+cd ClinicFlow
+dotnet ef database update --project ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj \
+    --startup-project ClinicFlow.API/ClinicFlow.API.csproj
+```
+
 ## Usage
 
 1. **Request a token**


### PR DESCRIPTION
## Summary
- add EF Core design package
- define indexes in `ClinicFlowDbContext`
- create an initial migration with schema and stored procedure
- document how to apply migrations

## Testing
- `dotnet ef migrations list --project ClinicFlow.Infrastructure/ClinicFlow.Infrastructure.csproj --startup-project ClinicFlow.API/ClinicFlow.API.csproj` *(fails: command not found)*
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836d358a588329a1dc108c977ba0bb