### PR TITLE
Enable Swagger UI

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -48,11 +48,15 @@ builder.Services
 builder.Services.AddAuthorization();
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<GetGreetingQuery>());
 builder.Services.AddValidatorsFromAssemblyContaining<RegisterUserCommand>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.MapGet("/", () => "Hello World!");
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cd ClinicFlow
 dotnet run --project ClinicFlow.API
 ```
 
+Once running, navigate to `http://localhost:5000/swagger` to explore the API using Swagger UI.
+
 The application listens on the URLs defined in `appsettings.json` and `launchSettings.json`.
 
 ## Database


### PR DESCRIPTION
## Summary
- reference `Swashbuckle.AspNetCore` in the API project
- register Swagger services in `Program.cs`
- enable Swagger middleware before routing
- document the Swagger UI URL

## Testing
- `dotnet test ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836eeba1708329a479b8a63cba6fa6