### PR TITLE
Secure appointment creation

### DIFF
--- a/ClinicFlow/ClinicFlow.API/Program.cs
+++ b/ClinicFlow/ClinicFlow.API/Program.cs
@@ -9,6 +9,8 @@ using Serilog;
 using ClinicFlow.Application.Greetings;
 using ClinicFlow.Application.Users;
 using ClinicFlow.Application.Common;
+using ClinicFlow.Application.Appointments;
+using System.Security.Claims;
 using ClinicFlow.Infrastructure.Data;
 using ClinicFlow.Infrastructure.Repositories;
 using ClinicFlow.Infrastructure.Services;
@@ -89,6 +91,22 @@ authGroup.MapPost("/login", async (IMediator mediator, LoginQuery query) =>
         return Results.Unauthorized();
     }
     return Results.Ok(new { token });
+});
+
+app.MapPost("/appointments", [Authorize] async (
+    IMediator mediator,
+    ClaimsPrincipal user,
+    CreateAppointmentCommand command) =>
+{
+    var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
+    if (string.IsNullOrEmpty(userIdClaim))
+    {
+        return Results.Unauthorized();
+    }
+
+    var userId = int.Parse(userIdClaim);
+    var result = await mediator.Send(command with { UserId = userId });
+    return Results.Ok(new { id = result });
 });
 
 

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommand.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommand.cs
@@ -2,4 +2,4 @@ using MediatR;
 
 namespace ClinicFlow.Application.Appointments;
 
-public record CreateAppointmentCommand(int PatientId, int DoctorId, DateTime ScheduledAt) : IRequest<int>;
+public record CreateAppointmentCommand(int PatientId, int DoctorId, DateTime ScheduledAt, int UserId) : IRequest<int>;

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandHandler.cs
@@ -20,7 +20,7 @@ public class CreateAppointmentCommandHandler : IRequestHandler<CreateAppointment
             PatientId = request.PatientId,
             DoctorId = request.DoctorId,
             ScheduledAt = request.ScheduledAt,
-            UserId = 0
+            UserId = request.UserId
         };
 
         return await _repository.AddAsync(appointment, cancellationToken);

--- a/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandValidator.cs
+++ b/ClinicFlow/ClinicFlow.Application/Appointments/CreateAppointmentCommandValidator.cs
@@ -15,5 +15,8 @@ public class CreateAppointmentCommandValidator : AbstractValidator<CreateAppoint
         RuleFor(x => x.ScheduledAt)
             .Must(d => d > DateTime.Now)
             .WithMessage("Scheduled time must be in the future");
+
+        RuleFor(x => x.UserId)
+            .GreaterThan(0);
     }
 }

--- a/ClinicFlow/ClinicFlow.Infrastructure/Services/TokenService.cs
+++ b/ClinicFlow/ClinicFlow.Infrastructure/Services/TokenService.cs
@@ -21,6 +21,7 @@ public class TokenService : ITokenService
     {
         var claims = new[]
         {
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
             new Claim(ClaimTypes.Name, user.Username)
         };
 

--- a/ClinicFlow/ClinicFlow.Tests/Api/AppointmentEndpointTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Api/AppointmentEndpointTests.cs
@@ -1,0 +1,49 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace ClinicFlow.Tests.Api;
+
+public class AppointmentEndpointTests : IClassFixture<TestApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public AppointmentEndpointTests(TestApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateAppointment_Unauthorized_Returns401()
+    {
+        var response = await _client.PostAsJsonAsync("/appointments", new
+        {
+            patientId = 1,
+            doctorId = 1,
+            scheduledAt = DateTime.UtcNow.AddHours(1)
+        });
+
+        Assert.Equal(System.Net.HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateAppointment_Authorized_ReturnsOk()
+    {
+        await _client.PostAsJsonAsync("/auth/register", new { username = "apptuser", password = "secret" });
+        var login = await _client.PostAsJsonAsync("/auth/login", new { username = "apptuser", password = "secret" });
+        login.EnsureSuccessStatusCode();
+        var token = (await login.Content.ReadFromJsonAsync<TokenResponse>())!.token;
+        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await _client.PostAsJsonAsync("/appointments", new
+        {
+            patientId = 1,
+            doctorId = 1,
+            scheduledAt = DateTime.UtcNow.AddHours(1)
+        });
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    private record TokenResponse(string token);
+}


### PR DESCRIPTION
## Summary
- require authentication token for `/appointments`
- include user id in JWT tokens
- capture user id when creating appointment
- validate `UserId` in command model
- test appointment endpoint authentication logic

## Testing
- `dotnet test ClinicFlow/ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68836fc255588329a6aaf8be9d8c175b