### PR TITLE
Fix interface implementation in RegisterUserCommandHandler

### DIFF
--- a/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
@@ -15,11 +15,12 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
         _repository = repository;
     }
 
-    public async Task Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    public async Task<Unit> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
     {
         var hash = HashPassword(request.Password);
         var user = new User { Username = request.Username, PasswordHash = hash };
         await _repository.AddAsync(user, cancellationToken);
+        return Unit.Value;
     }
 
     private static string HashPassword(string password)


### PR DESCRIPTION
## Summary
- fix return type of RegisterUserCommandHandler

## Testing
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68872bc3612c8329b19706f737f86596