### PR TITLE
Fix API DI packages

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -11,6 +11,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
+++ b/ClinicFlow/ClinicFlow.Application/Users/RegisterUserCommandHandler.cs
@@ -15,11 +15,12 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand>
         _repository = repository;
     }
 
-    public async Task Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    public async Task<Unit> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
     {
         var hash = HashPassword(request.Password);
         var user = new User { Username = request.Username, PasswordHash = hash };
         await _repository.AddAsync(user, cancellationToken);
+        return Unit.Value;
     }
 
     private static string HashPassword(string password)


### PR DESCRIPTION
## Summary
- add MediatR.Extensions.Microsoft.DependencyInjection package to ClinicFlow.API
- add FluentValidation.DependencyInjectionExtensions package to ClinicFlow.API
- ensure RegisterUserCommandHandler returns `Task<Unit>`

## Testing
- `dotnet build ClinicFlow.sln` *(fails: command not found)*
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj --no-build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68872bc3612c8329b19706f737f86596