### PR TITLE
Update MediatR extension package to v13

### DIFF
--- a/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
+++ b/ClinicFlow/ClinicFlow.API/ClinicFlow.API.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="13.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.0" />
   </ItemGroup>
 

--- a/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
+++ b/ClinicFlow/ClinicFlow.Application/ClinicFlow.Application.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="11.1.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="13.0.0" />
     <PackageReference Include="FluentValidation" Version="11.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- upgrade `MediatR.Extensions.Microsoft.DependencyInjection` package versions
- keep other package references the same

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build ClinicFlow.sln` *(fails: command not found)*
- `dotnet test ClinicFlow.Tests/ClinicFlow.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887317206708329bdb1572f26b88011