### PR TITLE
Add login test for valid credentials

### DIFF
--- a/ClinicFlow/ClinicFlow.Tests/Api/AuthEndpointTests.cs
+++ b/ClinicFlow/ClinicFlow.Tests/Api/AuthEndpointTests.cs
@@ -17,6 +17,18 @@ public class AuthEndpointTests : IClassFixture<TestApplicationFactory>
     }
 
     [Fact]
+    public async Task Login_ValidCredentials_ReturnsToken()
+    {
+        var payload = new { username = "apiuser", password = "secret" };
+
+        var response = await _client.PostAsJsonAsync("/api/auth/login", payload);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadFromJsonAsync<TokenResponse>();
+        Assert.False(string.IsNullOrEmpty(json?.token));
+    }
+
+    [Fact]
     public async Task RegisterAndLogin_Workflow()
     {
         var registerResponse = await _client.PostAsJsonAsync("/auth/register", new { username = "apiuser", password = "secret" });


### PR DESCRIPTION
## Summary
- add unit test ensuring login endpoint returns token for valid credentials

## Testing
- `dotnet test` *(fails: command not found; apt repositories 403 so dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689056d072948329a35d04ab653782dc