### PR TITLE
Configure Swagger and annotate API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ dotnet run --project ClinicFlow.API
 ```
 
 Once running, navigate to `http://localhost:5000/swagger` to explore the API using Swagger UI.
+Swagger is enabled only in development and includes a `Bearer` security scheme so you can authorize with a JWT token via the **Authorize** button.
 
 The application listens on the URLs defined in `appsettings.json` and `launchSettings.json`.
 


### PR DESCRIPTION
## Summary
- configure Swagger with OpenAPI info and JWT bearer security
- enable Swagger middleware only in development
- add descriptive tags, names and response metadata to minimal API endpoints
- document Swagger availability and JWT auth in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a645717108832984ac32ce28fb1e52